### PR TITLE
HUSH-2119 sensor_ecs_deployment: Initial ECS-based Terraform module

### DIFF
--- a/examples/base_deployment/outputs.tf
+++ b/examples/base_deployment/outputs.tf
@@ -1,0 +1,24 @@
+output "deployment_password_secret_arn" {
+  value       = module.sensor_daemon.deployment_password_secret_arn
+  description = "ARN of deployment_password (if created)"
+}
+
+output "acr_credentials_secret_arn" {
+  value       = module.sensor_daemon.acr_credentials_secret_arn
+  description = "ARN of ACR credentials secret (if created)"
+}
+
+output "ecs_service_name" {
+  value       = module.sensor_daemon.ecs_service_name
+  description = "The name of the ECS service"
+}
+
+output "ecs_service_arn" {
+  value       = module.sensor_daemon.ecs_service_arn
+  description = "The full ARN of the ECS service"
+}
+
+output "ecs_task_definition_arn" {
+  value       = module.sensor_daemon.ecs_task_definition_arn
+  description = "The full ARN of the ECS task definition"
+}


### PR DESCRIPTION
This is the initial implementation of the Terraform-based ECS deployment for the Hush sensor.

The module supports deploying the sensor as a Daemon service on EC2-based ECS clusters, including configuration injection via environment variables and secure secret handling via AWS Secrets Manager.

Highlights:
- Supports secret creation or referencing existing ARNs for deployment credentials and private registry (ACR) auth
- Injects runtime configuration via env vars instead of config.yaml
- Includes an example usage in `examples/base_deployment`
- Exposes outputs for ECS service, task definition, and deployment metadata

This sets the foundation for fully automating sensor rollout in ECS environments.
