### PR TITLE
HUSH-2137 examples: rename source to use public module registry

### DIFF
--- a/examples/existing_secret/main.tf
+++ b/examples/existing_secret/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 module "hush_service" {
-  source  = "hushsecurity/ecs/hush"
+  source  = "hushsecurity/ecs/aws"
   version = "~> 1.0"
 
   cluster_name       = var.cluster_name

--- a/examples/generated_secrets/main.tf
+++ b/examples/generated_secrets/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 module "hush_service" {
-  source  = "hushsecurity/ecs/hush"
+  source  = "hushsecurity/ecs/aws"
   version = "~> 1.0"
 
   cluster_name       = var.cluster_name


### PR DESCRIPTION
We renamed the repository in order to follow Terraform convention and now the source need to be adjusted accordingly.