### PR TITLE
HUSH-2826 vermon: Add Vermon auto-upgrade module for ECS deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-09-03
+
+### Added
+
+- `hush_vermon` module:
+  - ECS task definition and service for Vermon auto-upgrade functionality.
+  - Configurable environment variables including test mode support.
+  - Integration with existing container registry authentication.
+- Vermon configuration support:
+  - `enable_vermon` toggle to control Vermon deployment.
+  - `vermon_tag` variable for specifying Vermon container image tag.
+  - Test mode environment variables (`ECS_LASSIE_TEST_MODE`, `ECS_TEST_FORCE_UPDATE_IMAGE`).
+
+### Changed
+
+- Enhanced IAM permissions:
+  - Added ECS task management permissions (`ecs:DescribeTaskDefinition`, `ecs:ListTasks`, `ecs:DescribeTasks`) for Vermon functionality.
+  - Updated IAM policies to support both sensor and vermon operations.
+- Improved variable naming consistency:
+  - Renamed `sensor_tag` to `vermon_tag` in vermon module for semantic clarity.
+
 ## [1.0.0] - 2025-08-04
 
 ### Added
@@ -42,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First public release of the `terraform-hush-ecs` module.
 - Includes all modules, wiring, secrets, IAM roles, and ECS service definition.
 
-[unreleased]: https://github.com/hushsecurity/terraform-hush-ecs/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/hushsecurity/terraform-hush-ecs/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/hushsecurity/terraform-hush-ecs/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/hushsecurity/terraform-hush-ecs/compare/v0.0.1...v1.0.0
 [0.0.1]: https://github.com/hushsecurity/terraform-hush-ecs/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Reusable Terraform module for deploying **Hush Security components** on AWS ECS 
 ```
 .
 ├── examples
-│   └── base                         # Configuration to deploy the Hush ECS services on EC2-backed ECS
+│   ├── existing_secret              # Example using pre-existing secrets  
+│   └── generated_secrets            # Example creating new secrets
 ├── iam.tf                           # IAM role and policies for ECS execution
 ├── main.tf                          # Root module wiring IAM, secrets, ECS task
 ├── modules
-│   └── hush_sensor                  # Configuration for hush_sensor service module
+│   ├── hush_sensor                  # Configuration for hush_sensor service module
+│   └── hush_vermon                  # Configuration for hush_vermon auto-upgrade module
 ├── outputs.tf                       # Root outputs
 ├── variables.tf                     # Root input variables
 ├── secrets.tf                       # Secrets Manager integration
@@ -35,10 +37,12 @@ Reusable Terraform module for deploying **Hush Security components** on AWS ECS 
 
 ## ▶️ Usage
 
-1. Navigate to the example directory:
+1. Navigate to an example directory:
 
    ```bash
-   cd examples/base
+   cd examples/generated_secrets
+   # OR
+   cd examples/existing_secret
    ```
 
 2. Define your credentials and configuration in `terraform.tfvars`, for example:
@@ -89,6 +93,7 @@ Instead of secret values, use:
 
 - ECS DAEMON-style deployment (1 task per EC2 instance)
 - Deploys both `sensor` and `sensor-vector` containers
+- **Auto-upgrade capability via Vermon** (optional, enabled by default)
 - Supports private container registries (e.g. Azure Container Registry)
 - Secure secrets injection via AWS Secrets Manager
 - Configurable CPU/memory requests and limits
@@ -107,7 +112,7 @@ See [`outputs.tf`](./outputs.tf) for details. Notable outputs include:
 
 ## 🧪 Example
 
-For a working example, see [`examples/base`](./examples/base).
+For working examples, see [`examples/generated_secrets`](./examples/generated_secrets) and [`examples/existing_secret`](./examples/existing_secret).
 
 ---
 

--- a/examples/existing_secret/main.tf
+++ b/examples/existing_secret/main.tf
@@ -3,8 +3,7 @@ terraform {
 }
 
 module "hush_service" {
-  source  = "hushsecurity/ecs/aws"
-  version = "~> 1.0"
+  source = "../../"
 
   cluster_name       = var.cluster_name
   container_registry = var.container_registry

--- a/examples/existing_secret/outputs.tf
+++ b/examples/existing_secret/outputs.tf
@@ -1,14 +1,29 @@
-output "ecs_service_name" {
-  value       = module.hush_service.ecs_service_name
-  description = "The ECS service name"
+output "sensor_service_name" {
+  value       = module.hush_service.sensor_service_name
+  description = "The sensor ECS service name"
 }
 
-output "ecs_service_arn" {
-  value       = module.hush_service.ecs_service_arn
-  description = "The ECS service ARN"
+output "sensor_service_arn" {
+  value       = module.hush_service.sensor_service_arn
+  description = "The sensor ECS service ARN"
 }
 
-output "ecs_task_definition_arn" {
-  value       = module.hush_service.ecs_task_definition_arn
-  description = "The ECS task definition ARN"
+output "sensor_task_definition_arn" {
+  value       = module.hush_service.sensor_task_definition_arn
+  description = "The sensor ECS task definition ARN"
+}
+
+output "vermon_service_name" {
+  value       = module.hush_service.vermon_service_name
+  description = "The Vermon ECS service name"
+}
+
+output "vermon_service_arn" {
+  value       = module.hush_service.vermon_service_arn
+  description = "The Vermon ECS service ARN"
+}
+
+output "vermon_task_definition_arn" {
+  value       = module.hush_service.vermon_task_definition_arn
+  description = "The Vermon ECS task definition ARN"
 }

--- a/examples/generated_secrets/main.tf
+++ b/examples/generated_secrets/main.tf
@@ -3,8 +3,7 @@ terraform {
 }
 
 module "hush_service" {
-  source  = "hushsecurity/ecs/aws"
-  version = "~> 1.0"
+  source = "../../"
 
   cluster_name       = var.cluster_name
   container_registry = var.container_registry

--- a/examples/generated_secrets/outputs.tf
+++ b/examples/generated_secrets/outputs.tf
@@ -1,16 +1,31 @@
-output "ecs_service_name" {
-  value       = module.hush_service.ecs_service_name
-  description = "The ECS service name"
+output "sensor_service_name" {
+  value       = module.hush_service.sensor_service_name
+  description = "The sensor ECS service name"
 }
 
-output "ecs_service_arn" {
-  value       = module.hush_service.ecs_service_arn
-  description = "The ECS service ARN"
+output "sensor_service_arn" {
+  value       = module.hush_service.sensor_service_arn
+  description = "The sensor ECS service ARN"
 }
 
-output "ecs_task_definition_arn" {
-  value       = module.hush_service.ecs_task_definition_arn
-  description = "The ECS task definition ARN"
+output "sensor_task_definition_arn" {
+  value       = module.hush_service.sensor_task_definition_arn
+  description = "The sensor ECS task definition ARN"
+}
+
+output "vermon_service_name" {
+  value       = module.hush_service.vermon_service_name
+  description = "The Vermon ECS service name"
+}
+
+output "vermon_service_arn" {
+  value       = module.hush_service.vermon_service_arn
+  description = "The Vermon ECS service ARN"
+}
+
+output "vermon_task_definition_arn" {
+  value       = module.hush_service.vermon_task_definition_arn
+  description = "The Vermon ECS task definition ARN"
 }
 
 output "deployment_credentials_secret_arn" {

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 resource "aws_iam_role" "hush_ecs_role" {
   name = "hush-ecs-role"
 
@@ -24,6 +27,91 @@ resource "aws_iam_role_policy" "hush_ecs_role_policy" {
         Resource = [
           local.deployment_credentials_secret_arn,
           local.container_registry_credentials_secret_arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "hush_vermon_role" {
+  count = var.enable_vermon ? 1 : 0
+  name  = "hush-vermon-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Principal = { Service = "ecs-tasks.amazonaws.com" },
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "hush_vermon_role_policy" {
+  count = var.enable_vermon ? 1 : 0
+  name  = "hush-vermon-role-policy"
+  role  = aws_iam_role.hush_vermon_role[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["secretsmanager:GetSecretValue"],
+        Resource = [
+          local.deployment_credentials_secret_arn,
+          local.container_registry_credentials_secret_arn
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecs:UpdateService",
+          "ecs:DescribeServices"
+        ],
+        Resource = compact([
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${var.cluster_name}/${var.sensor_service_name}",
+          var.enable_vermon ? "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${var.cluster_name}/${var.vermon_service_name}" : ""
+        ])
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecs:DescribeClusters"
+        ],
+        Resource = [
+          "arn:aws:ecs:*:*:cluster/${var.cluster_name}"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecs:DescribeTaskDefinition"
+        ],
+        Resource = compact([
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task-definition/${var.sensor_task_definition_family}:*",
+          var.enable_vermon ? "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task-definition/${var.vermon_task_definition_family}:*" : ""
+        ])
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecs:ListServices"
+        ],
+        Resource = [
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${var.cluster_name}"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecs:ListTasks",
+          "ecs:DescribeTasks"
+        ],
+        Resource = [
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/${var.cluster_name}",
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task/${var.cluster_name}/*",
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:container-instance/${var.cluster_name}/*"
         ]
       }
     ]

--- a/main.tf
+++ b/main.tf
@@ -65,3 +65,29 @@ module "hush_sensor" {
   sensor_vector_image_repo = var.sensor_vector_image_repo
   sensor_tag               = var.sensor_tag
 }
+
+module "hush_vermon" {
+  count = var.enable_vermon ? 1 : 0
+
+  source = "./modules/hush_vermon"
+
+  task_definition_family = local.task_families.vermon
+  service_name           = var.vermon_service_name
+  cluster_name           = var.cluster_name
+  execution_role_arn     = aws_iam_role.hush_ecs_role.arn
+  vermon_task_role_arn   = aws_iam_role.hush_vermon_role[0].arn
+
+  deployment_name      = var.cluster_name
+  manage_task_families = local.manage_task_families
+
+  event_reporting_console = var.event_reporting_console
+  vermon_update_frequency = var.vermon_update_frequency
+
+  container_registry                        = var.container_registry
+  deployment_credentials_secret_list        = local.deployment_credentials_secret_list
+  container_registry_credentials_secret_arn = local.container_registry_credentials_secret_arn
+
+  vermon_image_repo        = var.vermon_image_repo
+  vermon_vector_image_repo = var.sensor_vector_image_repo
+  vermon_tag               = var.sensor_tag
+}

--- a/modules/hush_sensor/main.tf
+++ b/modules/hush_sensor/main.tf
@@ -1,7 +1,6 @@
 locals {
-  # ECS resource names and values
-  task_family  = "hush-sensor-service"
-  service_name = "hush-sensor-daemon"
+  task_family  = var.task_definition_family
+  service_name = var.service_name
   launch_type  = "EC2"
 }
 
@@ -29,6 +28,7 @@ resource "aws_ecs_task_definition" "hush_sensor_task_definition" {
       },
       environment = concat([
         { name = "DEPLOYMENT_KIND", value = "ecs" },
+        { name = "EXCLUDE_TASK_FAMILIES", value = var.exclude_task_families },
         { name = "ECS_CLUSTER", value = var.cluster_name },
         { name = "ECS_SERVICE", value = local.service_name },
         { name = "SELF_ECS_TASK_FAMILY", value = local.task_family },

--- a/modules/hush_sensor/outputs.tf
+++ b/modules/hush_sensor/outputs.tf
@@ -12,3 +12,13 @@ output "ecs_task_definition_arn" {
   value       = aws_ecs_task_definition.hush_sensor_task_definition.arn
   description = "The full ARN of the ECS task definition"
 }
+
+output "task_definition_family" {
+  value       = local.task_family
+  description = "The task definition family name"
+}
+
+output "ecs_task_family" {
+  value       = aws_ecs_task_definition.hush_sensor_task_definition.family
+  description = "The task family name for the sensor"
+}

--- a/modules/hush_sensor/variables.tf
+++ b/modules/hush_sensor/variables.tf
@@ -1,6 +1,17 @@
 # ─────────────────────────────────────────────
 # Required core deployment configuration
 # ─────────────────────────────────────────────
+variable "task_definition_family" {
+  description = "Name of the ECS task definition family for this sensor service"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the ECS service for this sensor"
+  type        = string
+  default     = "hush-sensor-daemon"
+}
+
 variable "cluster_name" {
   description = "Name of the ECS cluster to deploy into"
   type        = string
@@ -9,6 +20,14 @@ variable "cluster_name" {
     condition     = length(trim(var.cluster_name, " ")) > 0
     error_message = "The 'cluster_name' value is required and cannot be empty"
   }
+}
+
+# ─────────────────────────────────────────────
+# Container identification
+# ─────────────────────────────────────────────
+variable "exclude_task_families" {
+  description = "Comma-separated list of ECS task definition families that sensor should exclude from scanning"
+  type        = string
 }
 
 variable "container_registry" {

--- a/modules/hush_vermon/main.tf
+++ b/modules/hush_vermon/main.tf
@@ -1,0 +1,92 @@
+locals {
+  # ECS resource names and values
+  task_family  = var.task_definition_family
+  service_name = var.service_name
+  launch_type  = "EC2"
+}
+
+# Data sources for AWS region
+data "aws_region" "current" {}
+
+resource "aws_ecs_task_definition" "hush_vermon_task_definition" {
+  family                   = local.task_family
+  requires_compatibilities = [local.launch_type]
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.vermon_task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name              = "hush-vermon",
+      image             = "${var.container_registry}/${var.vermon_image_repo}:${var.vermon_tag}",
+      essential         = true,
+      memory            = var.vermon_container_memory,
+      memoryReservation = var.vermon_container_memory_reservation,
+      linuxParameters = {
+        initProcessEnabled = true
+      },
+      secrets = var.deployment_credentials_secret_list,
+      repositoryCredentials = {
+        credentialsParameter = var.container_registry_credentials_secret_arn
+      },
+      environment = [
+        { name = "AWS_REGION", value = data.aws_region.current.name },
+        { name = "DEPLOYMENT_KIND", value = "ecs" },
+        { name = "MANAGE_TASK_FAMILIES", value = var.manage_task_families },
+        { name = "ECS_CLUSTER", value = var.cluster_name },
+        { name = "SELF_ECS_TASK_FAMILY", value = local.task_family },
+        { name = "ECS_LAUNCH_TYPE", value = local.launch_type },
+        { name = "CHANNEL_DIGESTS_PERIOD", value = var.vermon_update_frequency },
+        { name = "CONTAINER_REGISTRY", value = var.container_registry },
+        { name = "DEPLOYMENT_NAME", value = var.deployment_name },
+        { name = "DEPLOYMENT_TAGS", value = jsonencode(var.deployment_tags) }
+      ],
+      mountPoints = [
+        { sourceVolume = "vector-socket", containerPath = "/tmp/vector" },
+        { sourceVolume = "host-dir", containerPath = "/var/lib/hush-security" }
+      ]
+    },
+    {
+      name              = "hush-vermon-vector",
+      image             = "${var.container_registry}/${var.vermon_vector_image_repo}:${var.vermon_tag}",
+      essential         = true,
+      memory            = var.vermon_vector_container_memory,
+      memoryReservation = var.vermon_vector_container_memory_reservation,
+      linuxParameters = {
+        initProcessEnabled = true
+      },
+      environment = [
+        { name = "AWS_REGION", value = data.aws_region.current.name },
+        { name = "DEPLOYMENT_KIND", value = "ecs" },
+        { name = "ECS_CLUSTER", value = var.cluster_name },
+        { name = "ECS_SERVICE", value = local.service_name },
+        { name = "ECS_TASK_DEFINITION", value = local.task_family },
+        { name = "ECS_LAUNCH_TYPE", value = local.launch_type },
+        { name = "EVENT_REPORTING_CONSOLE", value = var.event_reporting_console }
+      ],
+      secrets = var.deployment_credentials_secret_list,
+      repositoryCredentials = {
+        credentialsParameter = var.container_registry_credentials_secret_arn
+      },
+      mountPoints = [
+        { sourceVolume = "vector-socket", containerPath = "/tmp/vector" }
+      ]
+    }
+  ])
+
+  volume {
+    name = "vector-socket"
+  }
+
+  volume {
+    name      = "host-dir"
+    host_path = "/var/lib/hush-security"
+  }
+}
+
+resource "aws_ecs_service" "hush_vermon_service" {
+  name            = local.service_name
+  cluster         = var.cluster_name
+  launch_type     = local.launch_type
+  task_definition = aws_ecs_task_definition.hush_vermon_task_definition.arn
+  desired_count   = 1 # Single instance for cluster-wide operations
+}

--- a/modules/hush_vermon/outputs.tf
+++ b/modules/hush_vermon/outputs.tf
@@ -1,0 +1,24 @@
+output "ecs_service_name" {
+  value       = aws_ecs_service.hush_vermon_service.name
+  description = "The name of the Vermon ECS service"
+}
+
+output "ecs_service_arn" {
+  value       = aws_ecs_service.hush_vermon_service.id
+  description = "The full ARN of the Vermon ECS service"
+}
+
+output "ecs_task_definition_arn" {
+  value       = aws_ecs_task_definition.hush_vermon_task_definition.arn
+  description = "The full ARN of the Vermon ECS task definition"
+}
+
+output "task_definition_family" {
+  value       = local.task_family
+  description = "The task definition family name"
+}
+
+output "ecs_task_family" {
+  value       = aws_ecs_task_definition.hush_vermon_task_definition.family
+  description = "The task family name for the vermon"
+}

--- a/modules/hush_vermon/variables.tf
+++ b/modules/hush_vermon/variables.tf
@@ -1,0 +1,131 @@
+# ─────────────────────────────────────────────
+# Required core deployment configuration
+# ─────────────────────────────────────────────
+variable "task_definition_family" {
+  description = "Name of the ECS task definition family for this vermon service"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the ECS service for this vermon"
+  type        = string
+  default     = "hush-vermon"
+}
+
+variable "deployment_name" {
+  description = "Name/identifier for this deployment instance"
+  type        = string
+}
+
+variable "deployment_tags" {
+  description = "Tags to identify services belonging to this deployment"
+  type        = map(string)
+  default     = {}
+}
+
+# ─────────────────────────────────────────────
+# Container identification - using task definition families
+# ─────────────────────────────────────────────
+variable "manage_task_families" {
+  description = "Comma-separated list of ECS task definition families that vermon should manage and update"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the ECS cluster to deploy into"
+  type        = string
+
+  validation {
+    condition     = length(trim(var.cluster_name, " ")) > 0
+    error_message = "The 'cluster_name' value is required and cannot be empty"
+  }
+}
+
+variable "container_registry" {
+  description = "Container registry hostname"
+  type        = string
+  default     = "hushsecurity.azurecr.io"
+}
+
+variable "vermon_image_repo" {
+  description = "Repository name for the vermon container"
+  type        = string
+  default     = "vermon"
+}
+
+variable "vermon_vector_image_repo" {
+  description = "Repository name for the vector sidecar container"
+  type        = string
+  default     = "sensor-vector"
+}
+
+variable "vermon_tag" {
+  description = "Tag to use for images shared across components"
+  type        = string
+  default     = "v0"
+}
+
+# ─────────────────────────────────────────────
+# Runtime configuration and behavior toggles
+# ─────────────────────────────────────────────
+variable "event_reporting_console" {
+  description = "Enable console event reporting"
+  type        = string
+  default     = "heartbeat"
+}
+
+variable "vermon_update_frequency" {
+  description = "How often Vermon checks for updates (e.g., '8h', '5m')"
+  type        = string
+  default     = "8h"
+}
+
+# ─────────────────────────────────────────────
+# ECS Task sizing
+# ─────────────────────────────────────────────
+variable "vermon_container_memory" {
+  description = "Memory in MiB to allocate to Vermon container"
+  type        = number
+  default     = 256
+}
+
+variable "vermon_container_memory_reservation" {
+  description = "Memory reservation in MiB for Vermon container"
+  type        = number
+  default     = 64
+}
+
+variable "vermon_vector_container_memory" {
+  description = "Memory in MiB to allocate to Vermon Vector container"
+  type        = number
+  default     = 128
+}
+
+variable "vermon_vector_container_memory_reservation" {
+  description = "Memory reservation in MiB for Vermon Vector container"
+  type        = number
+  default     = 32
+}
+
+# ─────────────────────────────────────────────
+# Secret ARNs and credentials — injected from root via locals
+# ─────────────────────────────────────────────
+variable "container_registry_credentials_secret_arn" {
+  description = "ARN of the container registry secret"
+  type        = string
+}
+
+variable "execution_role_arn" {
+  description = "IAM role ARN used by ECS task execution"
+  type        = string
+}
+
+variable "vermon_task_role_arn" {
+  description = "IAM role ARN used by Vermon for ECS operations"
+  type        = string
+}
+
+variable "deployment_credentials_secret_list" {
+  description = "List of deployment credentials to inject into services"
+  type        = list(map(string))
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,16 @@
-output "ecs_service_name" {
+output "sensor_service_name" {
   value       = module.hush_sensor[0].ecs_service_name
-  description = "The ECS service name"
+  description = "The sensor ECS service name"
 }
 
-output "ecs_service_arn" {
+output "sensor_service_arn" {
   value       = module.hush_sensor[0].ecs_service_arn
-  description = "The ECS service ARN"
+  description = "The sensor ECS service ARN"
 }
 
-output "ecs_task_definition_arn" {
+output "sensor_task_definition_arn" {
   value       = module.hush_sensor[0].ecs_task_definition_arn
-  description = "The ECS task definition ARN"
+  description = "The sensor ECS task definition ARN"
 }
 
 output "deployment_credentials_secret_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,46 @@ output "sensor_task_definition_arn" {
   description = "The sensor ECS task definition ARN"
 }
 
+output "sensor_task_definition_family" {
+  value       = module.hush_sensor[0].task_definition_family
+  description = "The sensor task definition family name"
+}
+
+output "sensor_task_family" {
+  value       = module.hush_sensor[0].ecs_task_family
+  description = "The sensor ECS task family name"
+}
+
+output "vermon_service_name" {
+  value       = module.hush_vermon[0].ecs_service_name
+  description = "The Vermon ECS service name"
+}
+
+output "vermon_service_arn" {
+  value       = module.hush_vermon[0].ecs_service_arn
+  description = "The Vermon ECS service ARN"
+}
+
+output "vermon_task_definition_arn" {
+  value       = module.hush_vermon[0].ecs_task_definition_arn
+  description = "The Vermon ECS task definition ARN"
+}
+
+output "vermon_task_definition_family" {
+  value       = module.hush_vermon[0].task_definition_family
+  description = "The vermon task definition family name"
+}
+
+output "vermon_task_family" {
+  value       = module.hush_vermon[0].ecs_task_family
+  description = "The vermon ECS task family name"
+}
+
+output "manage_task_families" {
+  value       = local.manage_task_families
+  description = "Comma-separated list of task families used for Hush namespace-equivalent logic"
+}
+
 output "deployment_credentials_secret_arn" {
   value       = local.deployment_credentials_secret_arn
   description = "ARN of the deployment password and token secret"

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,12 @@ variable "enable_sensor" {
   default     = true
 }
 
+variable "enable_vermon" {
+  description = "Whether to deploy the Vermon auto-upgrade component"
+  type        = bool
+  default     = true
+}
+
 # ─────────────────────────────────────────────
 # Service naming configuration
 # ─────────────────────────────────────────────
@@ -87,6 +93,42 @@ variable "akeyless_gateway_domain" {
   description = "Custom Akeyless gateway domain (optional)"
   type        = string
   default     = ""
+}
+
+# ─────────────────────────────────────────────
+# Container image configuration
+# ─────────────────────────────────────────────
+variable "sensor_tag" {
+  description = "Tag to use for sensor container images"
+  type        = string
+  default     = "v0"
+}
+
+variable "sensor_image_repo" {
+  description = "Repository name for the sensor container"
+  type        = string
+  default     = "sensor"
+}
+
+variable "sensor_vector_image_repo" {
+  description = "Repository name for the vector sidecar container"
+  type        = string
+  default     = "sensor-vector"
+}
+
+variable "vermon_image_repo" {
+  description = "Repository name for the vermon container"
+  type        = string
+  default     = "vermon"
+}
+
+# ─────────────────────────────────────────────
+# Vermon auto-upgrade configuration
+# ─────────────────────────────────────────────
+variable "vermon_update_frequency" {
+  description = "How often Vermon checks for updates (e.g., '8h', '5m')"
+  type        = string
+  default     = "8h"
 }
 
 # ─────────────────────────────────────────────

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,33 @@ variable "enable_sensor" {
 }
 
 # ─────────────────────────────────────────────
+# Service naming configuration
+# ─────────────────────────────────────────────
+variable "sensor_service_name" {
+  description = "Name of the ECS service for the sensor"
+  type        = string
+  default     = "hush-sensor-daemon"
+}
+
+variable "vermon_service_name" {
+  description = "Name of the ECS service for vermon"
+  type        = string
+  default     = "hush-vermon"
+}
+
+variable "sensor_task_definition_family" {
+  description = "Name of the ECS task definition family for the sensor"
+  type        = string
+  default     = "hush-sensor-service"
+}
+
+variable "vermon_task_definition_family" {
+  description = "Name of the ECS task definition family for vermon"
+  type        = string
+  default     = "hush-vermon-service"
+}
+
+# ─────────────────────────────────────────────
 # Runtime configuration and behavior toggles
 # ─────────────────────────────────────────────
 variable "event_reporting_console" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "enable_sensor" {
 variable "enable_vermon" {
   description = "Whether to deploy the Vermon auto-upgrade component"
   type        = bool
-  default     = true
+  default     = false
 }
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Adds Vermon auto-upgrade capability to the ECS deployment module, enabling automatic updates of sensor deployments.

<img width="1149" height="62" alt="image" src="https://github.com/user-attachments/assets/3978df22-d364-4b00-92b7-39e2cd909895" />