### PR TITLE
HUSH-4168 coding: examples: Reorganize examples for simplicity and registry deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - 2025-01-16
+## [1.1.1] - 2025-12-22
+
+### Added
+
+- **Vermon Module**:
+  - Added `CHANNEL_DIGESTS_ENDPOINT` environment variable to enable digest-based auto-update functionality
+  - Endpoint is dynamically constructed from container registry: `https://hush-runtime-config.s3.amazonaws.com/cr-digests/${var.container_registry}/channels.json`
+
+### Changed
+
+- **Examples**:
+  - Reorganized examples for Terraform Registry deployment readiness
+  - Updated module source to use `hushsecurity/ecs/aws` with version constraints
+  - Simplified variables to essential parameters only
+  - Improved documentation with clearer quick-start guides
+  - Streamlined terraform.tfvars with clean placeholders
+
+### Fixed
+
+- **Outputs**:
+  - Added safe output handling with `try()` function for disabled services
+  - Prevents crashes when `enable_sensor = false` or `enable_vermon = false`
+  - All sensor and vermon outputs now return `null` safely when modules are disabled
+
+### Reverted
+
+- **Vermon Module**:
+  - Re-enabled `hush_vermon` module by default (reverted HUSH-2826 disable-by-default change)
+
+## [1.1.0] - 2025-09-16
 
 ### Added
 

--- a/examples/existing_secret/README.md
+++ b/examples/existing_secret/README.md
@@ -1,51 +1,65 @@
-# Existing Secret Example – ECS Sensor Deployment
+# Existing Secrets Example
 
-This example deploys the Hush ECS sensor service on EC2-backed ECS using the root Terraform module, referencing **pre-existing Secrets Manager ARNs**.
+Deploy Hush ECS services using **existing AWS Secrets Manager secrets** for credentials.
 
-## What It Does
+## Quick Start
 
-- Registers a daemon-mode ECS service (1 task per EC2 instance)
-- Defines a task with `sensor` and `sensor-vector` containers
-- Injects deployment and registry credentials via existing Secrets Manager ARNs
-- Creates a minimal ECS execution role with access to logs and secrets
-
-## Usage
-
-Create a `terraform.tfvars` file with the following:
+1. **Edit `terraform.tfvars`** with your AWS resources:
 
 ```hcl
-cluster_name                              = "your-ecs-cluster-name"
+cluster_name = "your-ecs-cluster-name"
 
-# Pre-existing Secrets Manager ARNs
-deployment_credentials_secret_arn         = "arn:aws:secretsmanager:...:hush-deployment-credentials-{suffix}"
-container_registry_credentials_secret_arn = "arn:aws:secretsmanager:...:hush-container-registry-credentials-{suffix}"
+deployment_credentials_secret_arn         = "arn:aws:secretsmanager:region:account-id:secret:hush-deployment-creds-XXXXXX"
+container_registry_credentials_secret_arn = "arn:aws:secretsmanager:region:account-id:secret:hush-registry-creds-XXXXXX"
 
-# AWSVPC networking (required - private subnets only)
-vpc_private_subnets = [
-  "subnet-xxxxxx",  # Private subnet A with NAT Gateway
-  "subnet-yyyyyy",  # Private subnet B with NAT Gateway
-  "subnet-zzzzzz"   # Private subnet C with NAT Gateway
-]
+vpc_private_subnets = ["subnet-xxx", "subnet-yyy", "subnet-zzz"]
+vpc_id              = "vpc-xxxxxxxxxxxxxxxxx"
+```
 
-# Option 1: Auto-create security group (recommended)
-vpc_id = "vpc-xxxxxxxxx"  # Auto-creates egress-only security group
-
-# Option 2: Use existing security groups (alternative to above)
-# security_groups = ["sg-xxxxxxxxx"]  # Must allow egress traffic
-````
-
-Then run:
+2. **Deploy:**
 
 ```bash
 terraform init
 terraform apply
 ```
 
-**Note:** This will create AWS resources and may incur costs. Run `terraform destroy` to clean up.
+3. **Clean up:**
+
+```bash
+terraform destroy
+```
+
+## Secret Format Requirements
+
+**Deployment credentials secret** (JSON):
+```json
+{
+  "deployment_token": "your-token",
+  "deployment_password": "your-password"
+}
+```
+
+**Container registry credentials secret** (JSON):
+```json
+{
+  "username": "your-username",
+  "password": "your-password"
+}
+```
+
+## What Gets Created
+
+- ✅ Hush sensor ECS service (daemon mode - 1 per EC2 instance)
+- ✅ Hush Vermon ECS service (auto-upgrade component)
+- ✅ ECS task definitions with sensor and vector containers
+- ✅ Security group (egress-only, auto-created)
+- ✅ IAM roles for ECS task execution
 
 ## Requirements
 
-| Name      | Version |
-| --------- | ------- |
-| Terraform | >= 1.0  |
+- Terraform >= 1.3
+- AWS provider >= 5.0
+- ECS cluster (EC2-backed)
+- Private subnets with NAT Gateway
+- Valid AWS Secrets Manager secrets
 | AWS       | >= 5.0  |

--- a/examples/existing_secret/main.tf
+++ b/examples/existing_secret/main.tf
@@ -1,17 +1,24 @@
 terraform {
   required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
 }
 
-module "hush_service" {
-  source = "../../"
+module "hush_ecs" {
+  source  = "hushsecurity/ecs/aws"
+  version = "~> 1.0" # Find the latest version at https://registry.terraform.io/modules/hushsecurity/ecs/aws/latest
 
-  cluster_name       = var.cluster_name
-  container_registry = var.container_registry
+  cluster_name = var.cluster_name
 
+  # Existing Secrets Manager ARNs
   deployment_credentials_secret_arn         = var.deployment_credentials_secret_arn
   container_registry_credentials_secret_arn = var.container_registry_credentials_secret_arn
 
+  # Networking
   vpc_private_subnets = var.vpc_private_subnets
-  security_groups     = var.security_groups
   vpc_id              = var.vpc_id
 }

--- a/examples/existing_secret/outputs.tf
+++ b/examples/existing_secret/outputs.tf
@@ -1,29 +1,29 @@
 output "sensor_service_name" {
-  value       = module.hush_service.sensor_service_name
+  value       = try(module.hush_ecs.sensor_service_name, null)
   description = "The sensor ECS service name"
 }
 
 output "sensor_service_arn" {
-  value       = module.hush_service.sensor_service_arn
+  value       = try(module.hush_ecs.sensor_service_arn, null)
   description = "The sensor ECS service ARN"
 }
 
-output "sensor_task_definition_arn" {
-  value       = module.hush_service.sensor_task_definition_arn
-  description = "The sensor ECS task definition ARN"
-}
-
 output "vermon_service_name" {
-  value       = module.hush_service.vermon_service_name
+  value       = try(module.hush_ecs.vermon_service_name, null)
   description = "The Vermon ECS service name"
 }
 
 output "vermon_service_arn" {
-  value       = module.hush_service.vermon_service_arn
+  value       = try(module.hush_ecs.vermon_service_arn, null)
   description = "The Vermon ECS service ARN"
 }
 
-output "vermon_task_definition_arn" {
-  value       = module.hush_service.vermon_task_definition_arn
-  description = "The Vermon ECS task definition ARN"
+output "deployment_credentials_secret_arn" {
+  value       = module.hush_ecs.deployment_credentials_secret_arn
+  description = "ARN of the deployment credentials secret"
+}
+
+output "container_registry_credentials_secret_arn" {
+  value       = module.hush_ecs.container_registry_credentials_secret_arn
+  description = "ARN of the container registry credentials secret"
 }

--- a/examples/existing_secret/variables.tf
+++ b/examples/existing_secret/variables.tf
@@ -1,56 +1,24 @@
-# ─────────────────────────────────────────────
-# Required core deployment configuration
-# ─────────────────────────────────────────────
 variable "cluster_name" {
   description = "Name of the ECS cluster to deploy into"
   type        = string
-
-  validation {
-    condition     = length(trim(var.cluster_name, " ")) > 0
-    error_message = "The cluster_name must be non-empty."
-  }
 }
 
-# ─────────────────────────────────────────────
-# Registry credentials
-# ─────────────────────────────────────────────
-variable "container_registry" {
-  description = "Container registry hostname"
+variable "deployment_credentials_secret_arn" {
+  description = "ARN of AWS Secrets Manager secret containing deployment credentials (JSON with deployment_token and deployment_password)"
   type        = string
-  default     = "hushsecurity.azurecr.io"
 }
 
 variable "container_registry_credentials_secret_arn" {
-  description = "Existing ARN for container registry credentials secret (optional)"
+  description = "ARN of AWS Secrets Manager secret containing container registry credentials (JSON with username and password)"
   type        = string
-  default     = null
 }
 
-# ─────────────────────────────────────────────
-# Deployment credentials
-# ─────────────────────────────────────────────
-variable "deployment_credentials_secret_arn" {
-  description = "If provided, deployment_token and deployment_password variables are ignored. The secret must be a JSON object with the fields \"deployment_token\" and \"deployment_password\"."
-  type        = string
-  default     = null
-}
-
-# ─────────────────────────────────────────────
-# AWSVPC networking configuration
-# ─────────────────────────────────────────────
 variable "vpc_private_subnets" {
-  description = "List of private subnet IDs for AWSVPC networking (must have NAT Gateway for internet access)"
+  description = "List of private subnet IDs (must have NAT Gateway for internet access)"
   type        = list(string)
-}
-
-variable "security_groups" {
-  description = "List of security group IDs for AWSVPC networking. If not provided, an egress-only security group will be created."
-  type        = list(string)
-  default     = []
 }
 
 variable "vpc_id" {
-  description = "VPC ID where security groups will be created (required only when security_groups is not provided)"
+  description = "VPC ID where security group will be created"
   type        = string
-  default     = ""
 }

--- a/examples/generated_secrets/README.md
+++ b/examples/generated_secrets/README.md
@@ -1,53 +1,62 @@
-# Upload Credentials Example – ECS Sensor Deployment
+# Generated Secrets Example
 
-This example deploys the Hush ECS sensor service on EC2-backed ECS using the root Terraform module, and uploads new deployment and registry credentials to AWS Secrets Manager.
+Deploy Hush ECS services and **automatically create AWS Secrets Manager secrets** from provided credentials.
 
-## What It Does
+## Quick Start
 
-- Registers a daemon-mode ECS service (1 task per EC2 instance)
-- Defines a task with `sensor` and `sensor-vector` containers
-- Uploads credentials to Secrets Manager for deployment and registry access
-- Creates a minimal ECS execution role with access to logs and secrets
-
-## Usage
-
-Create a `terraform.tfvars` file with the following:
+1. **Edit `terraform.tfvars`** with your configuration:
 
 ```hcl
-cluster_name                  = "your-ecs-cluster-name"
+cluster_name = "your-ecs-cluster-name"
 
-# Deployment credentials
-deployment_token              = "your-deployment-token"
-deployment_password           = "your-deployment-password"
+deployment_token    = "your-deployment-token"
+deployment_password = "your-deployment-password"
 
-# Container registry credentials
-container_registry_username   = "your-registry-username"
-container_registry_password   = "your-registry-password"
+container_registry_username = "your-registry-username"
+container_registry_password = "your-registry-password"
 
-# AWSVPC networking (required - private subnets only)
-vpc_private_subnets = [
-  "subnet-xxxxxx",  # Private subnet A with NAT Gateway
-  "subnet-yyyyyy",  # Private subnet B with NAT Gateway
-  "subnet-zzzzzz"   # Private subnet C with NAT Gateway
-]
+vpc_private_subnets = ["subnet-xxx", "subnet-yyy", "subnet-zzz"]
+vpc_id              = "vpc-xxxxxxxxxxxxxxxxx"
+```
 
-# Option 1: Auto-create security group (recommended)
-vpc_id = "vpc-xxxxxxxxx"  # Auto-creates egress-only security group
-
-# Option 2: Use existing security groups (alternative to above)
-# security_groups = ["sg-xxxxxxxxx"]  # Must allow egress traffic
-````
-
-Then run:
+2. **Deploy:**
 
 ```bash
 terraform init
 terraform apply
 ```
 
-**Note:** This will create AWS resources and may incur costs. Run `terraform destroy` to clean up.
+3. **Clean up:**
+
+```bash
+terraform destroy
+```
+
+## What Gets Created
+
+- ✅ Hush sensor ECS service (daemon mode - 1 per EC2 instance)
+- ✅ Hush Vermon ECS service (auto-upgrade component)
+- ✅ ECS task definitions with sensor and vector containers
+- ✅ **AWS Secrets Manager secrets** (created from your credentials)
+- ✅ Security group (egress-only, auto-created)
+- ✅ IAM roles for ECS task execution
+
+## How It Works
+
+The module creates two AWS Secrets Manager secrets:
+
+1. **Deployment credentials** - Contains `deployment_token` and `deployment_password`
+2. **Registry credentials** - Contains container registry `username` and `password`
+
+These secrets are securely injected into ECS task containers at runtime.
 
 ## Requirements
+
+- Terraform >= 1.3
+- AWS provider >= 5.0
+- ECS cluster (EC2-backed)
+- Private subnets with NAT Gateway
+- Valid Hush deployment credentials
 
 | Name      | Version |
 | --------- | ------- |

--- a/examples/generated_secrets/main.tf
+++ b/examples/generated_secrets/main.tf
@@ -1,20 +1,27 @@
 terraform {
   required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
 }
 
-module "hush_service" {
-  source = "../../"
+module "hush_ecs" {
+  source  = "hushsecurity/ecs/aws"
+  version = "~> 1.0" # Find the latest version at https://registry.terraform.io/modules/hushsecurity/ecs/aws/latest
 
-  cluster_name       = var.cluster_name
-  container_registry = var.container_registry
+  cluster_name = var.cluster_name
 
-  deployment_password = var.deployment_password
+  # Module will create secrets from these values
   deployment_token    = var.deployment_token
+  deployment_password = var.deployment_password
 
   container_registry_username = var.container_registry_username
   container_registry_password = var.container_registry_password
 
+  # Networking
   vpc_private_subnets = var.vpc_private_subnets
-  security_groups     = var.security_groups
   vpc_id              = var.vpc_id
 }

--- a/examples/generated_secrets/outputs.tf
+++ b/examples/generated_secrets/outputs.tf
@@ -1,39 +1,29 @@
 output "sensor_service_name" {
-  value       = module.hush_service.sensor_service_name
+  value       = try(module.hush_ecs.sensor_service_name, null)
   description = "The sensor ECS service name"
 }
 
 output "sensor_service_arn" {
-  value       = module.hush_service.sensor_service_arn
+  value       = try(module.hush_ecs.sensor_service_arn, null)
   description = "The sensor ECS service ARN"
 }
 
-output "sensor_task_definition_arn" {
-  value       = module.hush_service.sensor_task_definition_arn
-  description = "The sensor ECS task definition ARN"
-}
-
 output "vermon_service_name" {
-  value       = module.hush_service.vermon_service_name
+  value       = try(module.hush_ecs.vermon_service_name, null)
   description = "The Vermon ECS service name"
 }
 
 output "vermon_service_arn" {
-  value       = module.hush_service.vermon_service_arn
+  value       = try(module.hush_ecs.vermon_service_arn, null)
   description = "The Vermon ECS service ARN"
 }
 
-output "vermon_task_definition_arn" {
-  value       = module.hush_service.vermon_task_definition_arn
-  description = "The Vermon ECS task definition ARN"
-}
-
 output "deployment_credentials_secret_arn" {
-  value       = module.hush_service.deployment_credentials_secret_arn
-  description = "ARN of the deployment password and token secret"
+  value       = module.hush_ecs.deployment_credentials_secret_arn
+  description = "ARN of the deployment credentials secret (created by module)"
 }
 
 output "container_registry_credentials_secret_arn" {
-  value       = module.hush_service.container_registry_credentials_secret_arn
-  description = "ARN of the container registry credentials secret"
+  value       = module.hush_ecs.container_registry_credentials_secret_arn
+  description = "ARN of the container registry credentials secret (created by module)"
 }

--- a/examples/generated_secrets/variables.tf
+++ b/examples/generated_secrets/variables.tf
@@ -1,71 +1,37 @@
-# ─────────────────────────────────────────────
-# Required core deployment configuration
-# ─────────────────────────────────────────────
 variable "cluster_name" {
   description = "Name of the ECS cluster to deploy into"
   type        = string
-
-  validation {
-    condition     = length(trim(var.cluster_name, " ")) > 0
-    error_message = "The cluster_name must be non-empty."
-  }
 }
 
-# ─────────────────────────────────────────────
-# Registry credentials
-# ─────────────────────────────────────────────
-variable "container_registry" {
-  description = "Container registry hostname"
-  type        = string
-  default     = "hushsecurity.azurecr.io"
-}
-
-variable "container_registry_username" {
-  description = "Username for container registry pull access"
-  type        = string
-  default     = null
-}
-
-variable "container_registry_password" {
-  description = "Password for container registry pull access"
-  type        = string
-  sensitive   = true
-  default     = null
-}
-
-# ─────────────────────────────────────────────
-# Deployment credentials
-# ─────────────────────────────────────────────
 variable "deployment_token" {
-  description = "Deployment token"
+  description = "Deployment token for Hush service authentication"
   type        = string
   sensitive   = true
-  default     = null
 }
 
 variable "deployment_password" {
-  description = "Deployment password"
+  description = "Deployment password for Hush service authentication"
   type        = string
   sensitive   = true
-  default     = null
 }
 
-# ─────────────────────────────────────────────
-# AWSVPC networking configuration
-# ─────────────────────────────────────────────
+variable "container_registry_username" {
+  description = "Username for container registry authentication"
+  type        = string
+}
+
+variable "container_registry_password" {
+  description = "Password for container registry authentication"
+  type        = string
+  sensitive   = true
+}
+
 variable "vpc_private_subnets" {
-  description = "List of private subnet IDs for AWSVPC networking (must have NAT Gateway for internet access)"
+  description = "List of private subnet IDs (must have NAT Gateway for internet access)"
   type        = list(string)
-}
-
-variable "security_groups" {
-  description = "List of security group IDs for AWSVPC networking. If not provided, an egress-only security group will be created."
-  type        = list(string)
-  default     = []
 }
 
 variable "vpc_id" {
-  description = "VPC ID where security groups will be created (required only when security_groups is not provided)"
+  description = "VPC ID where security group will be created"
   type        = string
-  default     = ""
 }

--- a/modules/hush_vermon/main.tf
+++ b/modules/hush_vermon/main.tf
@@ -1,11 +1,10 @@
 locals {
-  # ECS resource names and values
-  task_family  = var.task_definition_family
-  service_name = var.service_name
-  launch_type  = "EC2"
+  task_family              = var.task_definition_family
+  service_name             = var.service_name
+  launch_type              = "EC2"
+  channel_digests_endpoint = "https://hush-runtime-config.s3.amazonaws.com/cr-digests/${var.container_registry}/channels.json"
 }
 
-# Data sources for AWS region
 data "aws_region" "current" {}
 
 resource "aws_ecs_task_definition" "hush_vermon_task_definition" {
@@ -37,6 +36,7 @@ resource "aws_ecs_task_definition" "hush_vermon_task_definition" {
         { name = "SELF_ECS_TASK_FAMILY", value = local.task_family },
         { name = "ECS_LAUNCH_TYPE", value = local.launch_type },
         { name = "CHANNEL_DIGESTS_PERIOD", value = var.vermon_update_frequency },
+        { name = "CHANNEL_DIGESTS_ENDPOINT", value = local.channel_digests_endpoint },
         { name = "CONTAINER_REGISTRY", value = var.container_registry },
         { name = "DEPLOYMENT_NAME", value = var.deployment_name },
         { name = "DEPLOYMENT_TAGS", value = jsonencode(var.deployment_tags) }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,50 +1,50 @@
 output "sensor_service_name" {
-  value       = module.hush_sensor[0].ecs_service_name
+  value       = try(module.hush_sensor[0].ecs_service_name, null)
   description = "The sensor ECS service name"
 }
 
 output "sensor_service_arn" {
-  value       = module.hush_sensor[0].ecs_service_arn
+  value       = try(module.hush_sensor[0].ecs_service_arn, null)
   description = "The sensor ECS service ARN"
 }
 
 output "sensor_task_definition_arn" {
-  value       = module.hush_sensor[0].ecs_task_definition_arn
+  value       = try(module.hush_sensor[0].ecs_task_definition_arn, null)
   description = "The sensor ECS task definition ARN"
 }
 
 output "sensor_task_definition_family" {
-  value       = module.hush_sensor[0].task_definition_family
+  value       = try(module.hush_sensor[0].task_definition_family, null)
   description = "The sensor task definition family name"
 }
 
 output "sensor_task_family" {
-  value       = module.hush_sensor[0].ecs_task_family
+  value       = try(module.hush_sensor[0].ecs_task_family, null)
   description = "The sensor ECS task family name"
 }
 
 output "vermon_service_name" {
-  value       = module.hush_vermon[0].ecs_service_name
+  value       = try(module.hush_vermon[0].ecs_service_name, null)
   description = "The Vermon ECS service name"
 }
 
 output "vermon_service_arn" {
-  value       = module.hush_vermon[0].ecs_service_arn
+  value       = try(module.hush_vermon[0].ecs_service_arn, null)
   description = "The Vermon ECS service ARN"
 }
 
 output "vermon_task_definition_arn" {
-  value       = module.hush_vermon[0].ecs_task_definition_arn
+  value       = try(module.hush_vermon[0].ecs_task_definition_arn, null)
   description = "The Vermon ECS task definition ARN"
 }
 
 output "vermon_task_definition_family" {
-  value       = module.hush_vermon[0].task_definition_family
+  value       = try(module.hush_vermon[0].task_definition_family, null)
   description = "The vermon task definition family name"
 }
 
 output "vermon_task_family" {
-  value       = module.hush_vermon[0].ecs_task_family
+  value       = try(module.hush_vermon[0].ecs_task_family, null)
   description = "The vermon ECS task family name"
 }
 


### PR DESCRIPTION
Simplify examples to be copy-paste ready for Terraform Registry users. Update module source reference, use proper version constraints, streamline variables to essentials only, and improve documentation with clearer quick-start guides.

In addition, found missing envar so added.