### PR TITLE
HUSH-4366 sensor: Add enable_java_probing variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-01-05
+
+### Added
+
+- Added `enable_java_probing` variable to control Java probing in the sensor
+- When set to `false`, passes `SNOOPY_DISABLE_JAVA_PROBING=true` to sensor container
+- Defaults to `true` (Java probing enabled by default)
+
 ## [1.1.1] - 2025-12-22
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ module "hush_sensor" {
   trace_host              = var.trace_host
   trace_pods_default      = var.trace_pods_default
   report_tls              = var.report_tls
+  enable_java_probing     = var.enable_java_probing
   cri_socket_path         = var.cri_socket_path
   docker_socket_path      = var.docker_socket_path
   akeyless_gateway_domain = var.akeyless_gateway_domain

--- a/modules/hush_sensor/main.tf
+++ b/modules/hush_sensor/main.tf
@@ -38,6 +38,7 @@ resource "aws_ecs_task_definition" "hush_sensor_task_definition" {
         { name = "TRACE_HOST", value = tostring(var.trace_host) },
         { name = "TRACE_PODS_DEFAULT", value = tostring(var.trace_pods_default) },
         { name = "REPORT_TLS", value = tostring(var.report_tls) },
+        { name = "SNOOPY_DISABLE_JAVA_PROBING", value = tostring(!var.enable_java_probing) },
         { name = "AKEYLESS_GATEWAY_DOMAIN", value = tostring(var.akeyless_gateway_domain) },
         { name = "EVENT_REPORTING_CONSOLE", value = var.event_reporting_console }
         ],

--- a/modules/hush_sensor/variables.tf
+++ b/modules/hush_sensor/variables.tf
@@ -81,6 +81,12 @@ variable "report_tls" {
   default     = false
 }
 
+variable "enable_java_probing" {
+  description = "Enable Java probing in the sensor"
+  type        = bool
+  default     = true
+}
+
 variable "cri_socket_path" {
   description = "Absolute path to the CRI socket used by the sensor (e.g., /var/run/containerd/containerd.sock)"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,12 @@ variable "report_tls" {
   default     = false
 }
 
+variable "enable_java_probing" {
+  description = "Enable Java probing in the sensor"
+  type        = bool
+  default     = true
+}
+
 variable "cri_socket_path" {
   description = "Absolute path to the CRI socket used by the sensor (e.g., /var/run/containerd/containerd.sock)"
   type        = string


### PR DESCRIPTION
Add optional `enable_java_probing` variable to control Java probing in the sensor.

## Changes
- Add `enable_java_probing` variable to root module and sensor module (default: `false`)
- Pass `SNOOPY_DISABLE_JAVA_PROBING` environment variable to sensor container
- Update CHANGELOG for v1.1.2 release

## Behavior
- **Default**: Java probing is **enabled** (`enable_java_probing = true`)
- **Opt-in to disable**: Set `enable_java_probing = false` to disable Java probing

Related: https://linear.app/hushsecurity/issue/HUSH-4366/variable-for-disabling-java-probing